### PR TITLE
Fixes: DM closed, Macro invokes and History file name

### DIFF
--- a/src/main/kotlin/me/jakejmattson/modmail/commands/ReportCommands.kt
+++ b/src/main/kotlin/me/jakejmattson/modmail/commands/ReportCommands.kt
@@ -15,16 +15,18 @@ fun reportCommands(configuration: Configuration, loggingService: LoggingService)
         description = Locale.CLOSE_DESCRIPTION
         execute(ChannelArg<TextChannel>("Report Channel").makeOptional { it.channel.asChannel() as TextChannel }) {
             val inputChannel = args.first
-            val channel = inputChannel.toReportChannel()?.channel
 
-            if (channel == null) {
+            val reportChannel = inputChannel.toReportChannel()
+
+            if (reportChannel == null) {
                 respond(createChannelError(inputChannel))
                 return@execute
             }
 
-            deletionQueue.add(channel.id)
-            channel.delete()
-            loggingService.commandClose(guild, channel.name, author)
+            reportChannel.report.release(discord.api)
+            deletionQueue.add(reportChannel.channel.id)
+            reportChannel.channel.delete()
+            loggingService.commandClose(guild, reportChannel.channel.name, author)
         }
     }
 
@@ -55,6 +57,8 @@ fun reportCommands(configuration: Configuration, loggingService: LoggingService)
             archiveChannel.createMessage {
                 content = archiveMessage
                 addFile("$${channel.name}.txt", channel.archiveString().toByteArray().inputStream())
+
+                reportChannel.report.release(discord.api)
                 deletionQueue.add(channel.id)
                 channel.delete()
             }

--- a/src/main/kotlin/me/jakejmattson/modmail/commands/ReportHelperCommands.kt
+++ b/src/main/kotlin/me/jakejmattson/modmail/commands/ReportHelperCommands.kt
@@ -1,5 +1,6 @@
 package me.jakejmattson.modmail.commands
 
+import com.gitlab.kordlib.common.exception.RequestException
 import com.gitlab.kordlib.core.behavior.channel.*
 import com.gitlab.kordlib.core.behavior.createTextChannel
 import com.gitlab.kordlib.core.entity.*
@@ -64,7 +65,14 @@ fun reportHelperCommands(configuration: Configuration,
             if (!hasValidState(this, guild, targetMember))
                 return@execute
 
-            targetMember.openReport(this)
+            try {
+                targetMember.openReport(this)
+            } catch (ex: RequestException) {
+                respond("Unable to contact the target user. " +
+                        "Direct messages are disabled or the bot is blocked.")
+
+                return@execute
+            }
         }
     }
 
@@ -78,8 +86,6 @@ fun reportHelperCommands(configuration: Configuration,
                 return@execute
             }
 
-            targetMember.mute()
-
             if (targetMember.isDetained()) {
                 respond("This member is already detained.")
                 return@execute
@@ -88,7 +94,17 @@ fun reportHelperCommands(configuration: Configuration,
             if (!hasValidState(this, guild, targetMember))
                 return@execute
 
-            targetMember.openReport(this, true)
+            try {
+                targetMember.openReport(this, true)
+            } catch (ex: RequestException) {
+                respond("Unable to contact the target user. " +
+                        "Direct messages are disabled or the bot is blocked. " +
+                        "Mute was not applied")
+
+                return@execute
+            }
+
+            targetMember.mute()
         }
     }
 

--- a/src/main/kotlin/me/jakejmattson/modmail/commands/ReportHelperCommands.kt
+++ b/src/main/kotlin/me/jakejmattson/modmail/commands/ReportHelperCommands.kt
@@ -174,7 +174,7 @@ fun reportHelperCommands(configuration: Configuration,
             }
 
             channel.createMessage {
-                addFile("$${user.id}.txt", history.inputStream())
+                addFile("$${user.id.value}.txt", history.inputStream())
             }
         }
     }

--- a/src/main/kotlin/me/jakejmattson/modmail/commands/ReportHelperCommands.kt
+++ b/src/main/kotlin/me/jakejmattson/modmail/commands/ReportHelperCommands.kt
@@ -66,7 +66,7 @@ fun reportHelperCommands(configuration: Configuration,
                 return@execute
 
             try {
-                targetMember.openReport(this)
+                targetMember.openReport(this, false)
             } catch (ex: RequestException) {
                 respond("Unable to contact the target user. " +
                         "Direct messages are disabled or the bot is blocked.")

--- a/src/main/kotlin/me/jakejmattson/modmail/preconditions/MacroPrecondition.kt
+++ b/src/main/kotlin/me/jakejmattson/modmail/preconditions/MacroPrecondition.kt
@@ -14,6 +14,8 @@ fun macroPrecondition() = precondition {
     val macro = macroService.getGuildMacros(guild!!).firstOrNull { it.name.toLowerCase() == commandName }
         ?: return@precondition fail()
 
+    message.delete()
+
     respond {
         val report = channel.toLiveReport()
 

--- a/src/main/kotlin/me/jakejmattson/modmail/services/ReportService.kt
+++ b/src/main/kotlin/me/jakejmattson/modmail/services/ReportService.kt
@@ -79,7 +79,7 @@ class ReportService(private val config: Configuration,
         with(user.findReport()) {
             val liveReport = this?.toLiveReport(message.kord) ?: return@with
 
-            if (safeMessage.isEmpty) return
+            if (safeMessage.isEmpty()) return
 
             val newMessage = liveReport.channel.createMessage(safeMessage)
             messages[message.id.value] = newMessage.id.value


### PR DESCRIPTION
A few fixes

- macro invoke is deleted upon macro invoke
- it now returns error if a users dm's are closed
- the name of file `history` generates has been fixed

did some thorough testing with it all seems to function as intended